### PR TITLE
Remove scheduler cleanup import from backend app

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -8,7 +8,7 @@ from flask_jwt_extended import JWTManager
 from flask_migrate import Migrate
 from flask_swagger_ui import get_swaggerui_blueprint
 from error_hanlers import register_error_handlers
-from scheduler import schedule_cleanups
+# from scheduler import schedule_cleanups
 import logging
 # from flask_socketio import SocketIO
 from events import register_socket_events


### PR DESCRIPTION
The import of the `schedule_cleanups` method from the `scheduler` module has been removed from the backend app. This may be a temporary change during testing or due to changes in the cleanup process of the appliances. This commit doesn't introduce any new functionality. The import might be reinstated in the future if necessary.