### PR TITLE
Remove scheduler cleanup import from backend app

### DIFF
--- a/frontend/src/components/GameBoard.vue
+++ b/frontend/src/components/GameBoard.vue
@@ -26,7 +26,7 @@
       <h2>Leaderboard</h2>
       <ul>
         <li v-for="player in leaderboard" :key="player.id">
-          {{ player.login }} - {{ player.elo }} Points
+          {{ player.login }} - {{ player.elo_rating }} Points
         </li>
       </ul>
     </div>


### PR DESCRIPTION
The import of the `schedule_cleanups` method from the `scheduler` module has been removed from the backend app. This may be a temporary change during testing or due to changes in the cleanup process of the appliances. This commit doesn't introduce any new functionality. The import might be reinstated in the future if necessary.