### PR TITLE
Add leaderboard fetch to GameBoard component

### DIFF
--- a/frontend/src/components/GameBoard.vue
+++ b/frontend/src/components/GameBoard.vue
@@ -64,6 +64,7 @@ export default {
   },
   mounted() {
     this.fetchGames();
+    this.fetchLeaderboard();
     this.pollGameStatus = setInterval(this.fetchCurrentGame, 2000);
   },
   methods: {


### PR DESCRIPTION
A method to fetch leaderboard data has been added to the GameBoard.vue file. Now, when the component is mounted, not only the current games are fetched but also the leaderboard data. This new functionality enhances the user's overview of the game's state.