### PR TITLE
Adjust player identification in leaderboard display

### DIFF
--- a/frontend/src/components/GameBoard.vue
+++ b/frontend/src/components/GameBoard.vue
@@ -26,7 +26,7 @@
       <h2>Leaderboard</h2>
       <ul>
         <li v-for="player in leaderboard" :key="player.id">
-          {{ player.login }} - {{ player.elo_rating }} Points
+          {{ player.name }} - {{ player.elo_rating }} Points
         </li>
       </ul>
     </div>


### PR DESCRIPTION
The displayed player identifier in the components/GameBoard.vue file has been changed from `player.login` to `player.name`. This change alters how players are identified in the leaderboard, making it easier for users to